### PR TITLE
README.md: Add update of docker-compose and make the ca last

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ See home page of our project: https://shieldoo.io
     - `AAD_TENANTID`: Your Azure AD tenant ID.
     - `GOOGLE_CLIENTID`: Your Google client ID.
     - `GOOGLE_CLIENTSECRET`: Your Google client secret.
-8. Run `docker-compose up -d` to start the Shieldoo Mesh server.
+8. Run `. .env;sed -i s/shieldoodev.cloudfield.dev/$SHIELDOO_DOMAIN/ docker-compose.yaml`
+   to update the `docker-compose.yaml` with your `$SHIELDOO_DOMAIN`.
+9. Run `docker-compose up -d` to start the Shieldoo Mesh server.
 
 > :warning: **Warning** -
 > For a production environment, generate the following secrets:
@@ -146,6 +148,6 @@ To set up a Nebula CA, you'll need:
 #### 2. A Nebula certificate authority, which will be the root of trust for a shieldoo network.
 
   ```
-  ./nebula-cert ca -name "Myorganization, Inc"
+  ./nebula-cert ca -duration 118760h -name "Myorganization, Inc"
   ```
-  This will create files named `ca.key` and `ca.cert` in the current directory. The `ca.key` file is the most sensitive file you'll create, because it is the key used to sign the certificates for individual nebula nodes/hosts. Please store this file in folder `shieldoo-mesh-admin/ca`.
+  This will create files named `ca.key` and `ca.cert` in the current directory. The `ca.key` file is the most sensitive file you'll create, because it is the key used to sign the certificates for individual nebula nodes/hosts. Move both files to the folder `shieldoo-mesh-admin/ca`.


### PR DESCRIPTION
@valda-z: For the admin service to work with different domains, the docker-compose.yaml must also be updated.

The cert generated by `nebula-cert ca` is only valid for 365 days by default. I guess this should be longer, so I add `-duration 87600h` (10 years)

I think it would be better if two CAs would be created and supported to allow rotating for rotating the CAs in case of a compromise. The latest nebula supports encrypting the CA key, which would protect against someone unauthorized reading the ca.key having CA powers.

I assume, both files `ca.crt` and `ca.key` must be in `shieldoo-mesh-admin`, because the signed keys would have to match the `ca.crt.`

For me, updating either one currently does not work because the nebula parser fails to parse them, e.g.:
```
shieldoo-mesh-admin_1 msg="error while parsing ca-key: input did not contain a valid PEM encoded block"
shieldoo-mesh-admin_1 msg="error nebula sign(): input did not contain a valid PEM encoded block"
```